### PR TITLE
add nip98 extractor to auth handler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1935,6 +1935,7 @@ dependencies = [
  "chrono",
  "dotenvy",
  "env_logger",
+ "futures",
  "hmac 0.12.1",
  "jsonwebtoken",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ uuid = { version = "0.8", features = ["v4"] }
 chrono = { version = "0.4", features = ["serde"] }
 dotenvy = "*"
 env_logger = "0.10"
+futures = "0.3.28"
 validator = "0.14"
 serde_json = "1.0"
 rand = "0.8"


### PR DESCRIPTION
added a simple actix-web extractor to verify and obtain the pubkey from the nip98 auth header  